### PR TITLE
paginationの1ページあたりコンテンツ数をテスト時に少なくしたままにしていたのを修正

### DIFF
--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -17,7 +17,7 @@ export async function getStaticPaths({ paginate }: GetStaticPathsOptions) {
   const allPostsSorted = allPosts.sort(
     (a, b) => new Date(b.data.pubDate).valueOf() - new Date(a.data.pubDate).valueOf()
   )
-  return paginate(allPostsSorted, { pageSize: 3 });
+  return paginate(allPostsSorted, { pageSize: 10 });
 }
 
 const { page } = Astro.props


### PR DESCRIPTION
paginationのテスト時にページあたりコンテンツ数を少なくしたままにしていたのを修正した。