### PR TITLE
ドメインの変更に対応

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -3,4 +3,4 @@
 
 export const SITE_TITLE = 'いぶろぐ雑記';
 export const SITE_DESCRIPTION = 'ITとか、UXライティングとか、車とか';
-export const SITE_BASE_URL = 'https://ibulog.page';
+export const SITE_BASE_URL = 'https://ibulog.me';


### PR DESCRIPTION
ibulog.pageからibulog.meへのドメイン変更に伴い、サイトマップを出力するための設定を変更した。