### PR TITLE
fix: 目次を表示する見出しをh2以下に限定する

### DIFF
--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -84,7 +84,7 @@ const pageKind = 'Blog'
 				<div class="toc">
 					<h2>目次</h2>
 					<ul>
-						{headings.map((heading) => (
+						{headings.filter(heading => heading.depth < 3).map((heading) => (
 							<li>
 								<a href={`#${heading.slug}`}>{heading.text}</a>
 							</li>


### PR DESCRIPTION
h5まで目次に表示していたが、　目次が長くなりすぎてしまうので、h2までに表示するよう変更する。